### PR TITLE
Make matplotlib dependency optional

### DIFF
--- a/pysmac/analyzer.py
+++ b/pysmac/analyzer.py
@@ -7,9 +7,10 @@ import re
 
 
 import numpy as np
-import matplotlib.pyplot as plt
-#import matplotlib.cm as pltcm
-#from matplotlib.widgets import CheckButtons
+try:
+    import matplotlib.pyplot as plt
+except ImportError:
+    raise ImportError('pySMAC was not installed with analyzer support.')
 
 import sys
 sys.path.append('/home/sfalkner/repositories/github/pysmac/')

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name = 'pysmac',
     version = '0.9.1',
     packages = find_packages(),
-    install_requires = ['docutils>=0.3', 'setuptools', 'numpy', 'matplotlib', 'pynisher'],
+    install_requires = ['docutils>=0.3', 'setuptools', 'numpy', 'pynisher'],
     author = "Stefan Falkner and Tobias Domhan (python wrapper). Frank Hutter, Holger Hoos, Kevin Leyton-Brown, Kevin Murphy and Steve Ramage (SMAC)",
     author_email = "sfalkner@informatik.uni-freiburg.de",
     description = "python interface to the hyperparameter optimization tool SMAC.",
@@ -13,4 +13,7 @@ setup(
     license = "SMAC is free for academic & non-commercial usage. Please contact Frank Hutter(fh@informatik.uni-freiburg.de) to discuss obtaining a license for commercial purposes.",
     url = "http://www.cs.ubc.ca/labs/beta/Projects/SMAC/",
     download_url = 'https://github.com/sfalkner/pysmac/tarball/0.9'
+    extras_require={
+        'analyzer': ['matplotlib'],
+    },
 )


### PR DESCRIPTION
Matplotlib is only needed for the analyzer, which may not be used by all users.
