### PR TITLE
Fix parsing of the config string for the case that features are used.

### DIFF
--- a/pysmac/remote_smac.py
+++ b/pysmac/remote_smac.py
@@ -215,7 +215,7 @@ class remote_smac(object):
         config_dict={}
 
                 
-        config_dict['instance']      = int(los[0][3:])
+        config_dict['instance']      = int(los[0].split(",")[0][3:])
         config_dict['instance_info'] = str(los[1])
         config_dict['cutoff_time']   = float(los[2])
         config_dict['cutoff_length'] = float(los[3])


### PR DESCRIPTION
When features are used, SMAC appends the features to the instance id as comma separated values (no spaces). The additional `.split(",")[0]` ensures that the are capped off so we can parse the instance number as usual. I tested this fix for backwards compatibility when using no features.
