### PR TITLE
Fix more of the feature stuff.

### DIFF
--- a/pysmac/optimizer.py
+++ b/pysmac/optimizer.py
@@ -190,7 +190,7 @@ class SMAC_optimizer(object):
                 for feature_vector in  train_instance_features:
                     if (len(train_instance_features) != nf):
                         raise ValueError("You have to specify the same number of features for every instance!")
-                self.smac_options['feature_file'] = os.path.join(self.working_directory ,'instances.dat')
+                self.smac_options['feature_file'] = os.path.join(self.working_directory ,'features.dat')
                 
 
 

--- a/pysmac/remote_smac.py
+++ b/pysmac/remote_smac.py
@@ -215,7 +215,7 @@ class remote_smac(object):
         config_dict={}
 
                 
-        config_dict['instance']      = int(los[0].split(",")[0][3:])
+        config_dict['instance']      = int(los[0][3:])
         config_dict['instance_info'] = str(los[1])
         config_dict['cutoff_time']   = float(los[2])
         config_dict['cutoff_length'] = float(los[3])


### PR DESCRIPTION
As promised here is the bug fix. The problem was that the instances.dat was wrongly overridden with the contents of the features.dat (wrong filename in the code). This caused SMAC to report the entire line form the feature file as the instance ID.
In my first pull request is got around this issue by extracting just the instance ID from the combination of instance ID and feature vector that SMAC reported. This (surprisingly) worked quite well but now SMAC would also treat the header of the features file as an instance, which obviously makes no sense.

So in this pull request I undid my weird parsing code in remote_smac.py and just fixed the file name instead.
