### PR TITLE
Add a write pcs function

### DIFF
--- a/pysmac/utils/smac_input_readers.py
+++ b/pysmac/utils/smac_input_readers.py
@@ -66,6 +66,37 @@ def read_pcs(filename):
             
     return param_dict, conditions, forbiddens
 
+def write_pcs(pcs_filename, parameters, forbiddens, conditionals)
+    ''' Function to write a SMAC PCS file'''
+    with open(pcs_filename, 'w') as out:
+        # Parameters
+        out.write("# Parameters\n")
+        for param, info in parameters.iteritems():
+            if param == 'algorithm': # Handle this specially because merge_configuration_spaces doesn't return a set
+                values = set(info[1])
+                default = info[2]
+            else:
+                values = info[0]
+                default = info[1]
+            if isinstance(values, set): # Categorical
+                line = "%(param)s {%(values)s} [%(default)s]" % dict(param=param, values=",".join(values), default=default)
+            else:
+                _type = '' if len(info) == 2 else info[2][0]
+                if _type == 'i':
+                    values = map(int, info[0])
+                    default = int(info[1])
+                line = "%(param)s %(values)s [%(default)s] %(_type)s" % dict(param=param, values=values, default=default, _type=_type)
+            out.write(line +'\n')
+        
+        # Conditionals
+        out.write("# Conditionals\n")
+        for conditional in conditionals:
+            out.write(conditional +'\n')
+        
+        out.write("# Forbidden\n")
+        # Forbidden
+        for forbidden in forbiddens:
+            out.write(forbidden +'\n')
 
 def read_scenario_file(fn):
     """ Small helper function to read a SMAC scenario file.


### PR DESCRIPTION
I've been using this project to merge parameter spaces of some SAT solvers for which I have PCS files. So thanks for writing the `read_pcs` and `merge_configuration_space` functions! However, I had no way to get a PCS file back out of this library, so I had to write this function to get the pcs file back out.
