### PR TITLE
Rstrip conditionals before adding the && condition

### DIFF
--- a/pysmac/utils/pcs_merge.py
+++ b/pysmac/utils/pcs_merge.py
@@ -44,7 +44,7 @@ def merge_configuration_spaces(*args, **kwargs):
 			for p in params:
 				c = (re.subn( p, name + '_' + p , c)[0])
 			
-			conditionals.append( c + ' && algorithm == '+name)
+			conditionals.append( c.rstrip() + ' && algorithm == '+name)
 	
 		# add new conditionals
 		for p in params:


### PR DESCRIPTION
If c ends in a newline character (can happen when using read_pcs), the && part of the conditional falls onto a new line
